### PR TITLE
break:fix: never apply `webpackConfig.externals` into process of doc,…

### DIFF
--- a/src/getWebpackConfig.js
+++ b/src/getWebpackConfig.js
@@ -134,6 +134,6 @@ export default function (source, asset, dest, cwd, tpl, config) {
       title: 'title',
     }),
   ];
-
+  webpackConfig.externals = {};
   return webpackConfig;
 }


### PR DESCRIPTION
… only support resolving dependencies from `node_modules`