### PR TITLE
enhance: support mobile screen by `viewport` meta

### DIFF
--- a/tpl/index.ejs
+++ b/tpl/index.ejs
@@ -6,6 +6,7 @@
     <title>
       <%= PKG.name %>@<%= PKG.version %>
     </title>
+    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no">
     <link href="//os.alipayobjects.com/rmsportal/iUKcdtKUFtONTig.css" rel="stylesheet"/>
     <style type="text/css">
       @font-face {


### PR DESCRIPTION
添加 `<meta name="viewport">` 使默认 `index.ejs` 模板适配移动端布局