### PR TITLE
feat:keep webpack alias and plugins instead of create new

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atool-doc",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Static demo site generator based on atool-build & dora.",
   "keywords": [
     "atool",

--- a/src/getWebpackConfig.js
+++ b/src/getWebpackConfig.js
@@ -51,10 +51,10 @@ export default function (source, asset, dest, cwd, tpl, config) {
   webpackConfig.demoSource = source;
 
   webpackConfig.resolve.root = cwd;
-  webpackConfig.resolve.alias = {
+  webpackConfig.resolve.alias = Object.assign({}, webpackConfig.resolve.alias, {
     [`${pkg.name}$`]: join(cwd, 'index.js'),
     [pkg.name]: cwd,
-  };
+  });
 
   webpackConfig.resolve.modulesDirectories.push(join(root, 'node_modules'));
   webpackConfig.resolveLoader.modulesDirectories.push(join(root, 'node_modules'));
@@ -110,7 +110,7 @@ export default function (source, asset, dest, cwd, tpl, config) {
     link[path.relative(source, key)] = key;
   });
 
-  webpackConfig.plugins = [
+  webpackConfig.plugins.push(
     new ProgressPlugin((percentage, msg) => {
       const stream = process.stderr;
       if (stream.isTTY && percentage < 0.71) {
@@ -130,7 +130,7 @@ export default function (source, asset, dest, cwd, tpl, config) {
       },
       title: 'title',
     }),
-  ];
+  );
   webpackConfig.externals = {};
   return webpackConfig;
 }

--- a/src/getWebpackConfig.js
+++ b/src/getWebpackConfig.js
@@ -110,7 +110,7 @@ export default function (source, asset, dest, cwd, tpl, config) {
     link[path.relative(source, key)] = key;
   });
 
-  webpackConfig.plugins.push(
+  webpackConfig.plugins = [
     new ProgressPlugin((percentage, msg) => {
       const stream = process.stderr;
       if (stream.isTTY && percentage < 0.71) {
@@ -130,7 +130,7 @@ export default function (source, asset, dest, cwd, tpl, config) {
       },
       title: 'title',
     }),
-  );
+  ];
   webpackConfig.externals = {};
   return webpackConfig;
 }


### PR DESCRIPTION
In my project's `webpack.config.js`, I have `alias` and `plugins` myself. Keep it instead of discarding them